### PR TITLE
Clarify upper limit to number of results

### DIFF
--- a/UserAPI/Friends.md
+++ b/UserAPI/Friends.md
@@ -16,7 +16,7 @@ Yes
 Field | Type | Optional | Description
 ------|------|----------|------------
 offset | int | Yes | from where
-n | int | Yes | How many
+n | int | Yes | How many (maximum of 100)
 offline | boolean | Yes | Should return online friends
 
 ## Returns 


### PR DESCRIPTION
You get a 400 error with no useful explanation if n > 100.
