### PR TITLE
Fix the endpoint of Choose Avatar

### DIFF
--- a/AvatarAPI/ChooseAvatar.md
+++ b/AvatarAPI/ChooseAvatar.md
@@ -6,7 +6,7 @@ This API allows you to dynamically choose an avatar. This will work on any avata
 PUT
 
 ## Endpoint
-https://api.vrchat.cloud/api/1/avatar/[ID]/select
+https://api.vrchat.cloud/api/1/avatars/[ID]/select
 
 ID - the avatar id
 


### PR DESCRIPTION
At least now, the URL using `avatar` says `{"error": "The endpoint you're looking for is not implemented by our system.""status_code": 501}` and the URL with `avatars` works. I don't know whether this is a typo or a breaking change.