### PR TITLE
Fix Broken_Link in NotificationAPI column

### DIFF
--- a/NotificationAPI/Delete.md
+++ b/NotificationAPI/Delete.md
@@ -19,4 +19,4 @@ Yes (See [here](Authorization.md) for details)
 
 ## Returns
 
-[`Notification object`]("Objects/Notification.md?id=notification-object")
+[`Notification object`](Objects/Notification?id=notification-object)

--- a/NotificationAPI/GetAll.md
+++ b/NotificationAPI/GetAll.md
@@ -23,4 +23,4 @@ after | date | Yes | Only return notifications sent after this date
 
 ## Returns
 
-Array of [`Notification objects`]("Objects/Notification.md?id=notification-object")
+Array of [`Notification objects`](Objects/Notification?id=notification-object)

--- a/NotificationAPI/MarkAsSeen.md
+++ b/NotificationAPI/MarkAsSeen.md
@@ -17,4 +17,4 @@ Yes (See [here](Authorization.md) for details)
 
 ## Returns
 
-[`Notification object`]("Objects/Notification.md?id=notification-object")
+[`Notification object`](Objects/Notification?id=notification-object)

--- a/NotificationAPI/SendNotification.md
+++ b/NotificationAPI/SendNotification.md
@@ -20,7 +20,7 @@ Yes (See [here](Authorization.md) for details)
 
 Field | Type | Optional | Description
 ------|------|----------|------------
-type | [`NotificationType`]("Objects/Notification.md?id=notification") | No | The type of notification to send
+type | [`NotificationType`](Objects/Notification?id=notification) | No | The type of notification to send
 message | string | Yes | The message to send
 details | json as string | Yes | Details for some notifications
 


### PR DESCRIPTION
\[EN\](Translated with DeepL, and configed me)
As the title says.
This PR fix It: Some links in the "NotificationAPI" column that couldn't be skipped.
Also, because of the difference of ".md" and ".md" at the end of a sentence or not, it was unified to not add ".md" only to the "NotificationAPI" column.

\[JP\](Original)
題名の通りです。
"NotificationAPI"のカラムの中で一部飛べないリンクがありましたのでその問題を修正しています。
あと、文末に".md"をつけるかつけないかばらばらだったので"NotificationAPI"に飛ぶ分だけはつけないのに統一しました。
