### PR TITLE
Fixed links to work in both Pages and in repo

### DIFF
--- a/Authorization.md
+++ b/Authorization.md
@@ -15,4 +15,4 @@ Each cookie counts towards a "session" count (which is the amount of active auth
 
 You can run out of sessions, and when you do you will be unable to do more authorization required request without an authorization cookie.
 
-You can expire authorization cookies either by not using them for < period of time > or by using the [`Logout endpoint`](https://vrchatapi.github.io/#/UserAPI/Logout)
+You can expire authorization cookies either by not using them for < period of time > or by using the [`Logout endpoint`](/UserAPI/Logout.md)

--- a/AvatarAPI/ChooseAvatar.md
+++ b/AvatarAPI/ChooseAvatar.md
@@ -1,6 +1,6 @@
 # Choose Avatar
 
-This API allows you to dynamically choose an avatar. This will work on any avatar;  
+This API allows you to dynamically choose an avatar. This will work on any avatar;
 Doesn't update in-game instantly.
 
 ## Request Method
@@ -12,8 +12,8 @@ https://api.vrchat.cloud/api/1/avatars/[ID]/select
 ID - the avatar id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Current User object`](Objects/User.md?id=current-user-object)
+[`Current User object`](/Objects/User.md#current-user-object)

--- a/AvatarAPI/DeleteAvatar.md
+++ b/AvatarAPI/DeleteAvatar.md
@@ -13,8 +13,8 @@ https://api.vrchat.cloud/api/1/avatars/[ID]
 ID - the avatar id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Avatar object`](Objects/Avatar.md?id=avatar-object)
+[`Avatar object`](/Objects/Avatar.md#avatar-object)

--- a/AvatarAPI/GetByID.md
+++ b/AvatarAPI/GetByID.md
@@ -11,8 +11,8 @@ https://api.vrchat.cloud/api/1/avatars/[ID]
 ID - the avatar id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Avatar object`](Objects/Avatar.md?id=avatar-object)
+[`Avatar object`](/Objects/Avatar.md#avatar-object)

--- a/AvatarAPI/ListAvatars.md
+++ b/AvatarAPI/ListAvatars.md
@@ -9,7 +9,7 @@ GET
 https://api.vrchat.cloud/api/1/avatars
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 
@@ -57,4 +57,4 @@ platform | string | yes | The platform the world support
 
 ## Returns
 
-Array of [`Avatar objects`](Objects/Avatar.md?id=avatar-object)
+Array of [`Avatar objects`](/Objects/Avatar.md#avatar-object)

--- a/AvatarAPI/SaveAvatar.md
+++ b/AvatarAPI/SaveAvatar.md
@@ -22,11 +22,11 @@ Create avatar
 ID - the user id
 
 ## Parameters
-Any field in the [avatar](AvatarAPI/GetByID.md) object
+Any field in the [avatar](/AvatarAPI/GetByID.md) object
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Avatar object`](Objects/Avatar.md?id=avatar-object)
+[`Avatar object`](/Objects/Avatar.md#avatar-object)

--- a/FavoritesAPI/AddFavorite.md
+++ b/FavoritesAPI/AddFavorite.md
@@ -12,7 +12,7 @@ POST
 https://api.vrchat.cloud/api/1/favorites
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 

--- a/FavoritesAPI/DeleteFavorite.md
+++ b/FavoritesAPI/DeleteFavorite.md
@@ -11,7 +11,7 @@ https://api.vrchat.cloud/api/1/favorites/[ID]
 ID - The Favorite Id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/FavoritesAPI/GetFavorite.md
+++ b/FavoritesAPI/GetFavorite.md
@@ -11,7 +11,7 @@ https://api.vrchat.cloud/api/1/favorites/[ID]
 ID - The Favorite Id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/FavoritesAPI/ListAllFavorites.md
+++ b/FavoritesAPI/ListAllFavorites.md
@@ -9,7 +9,7 @@ GET
 https://api.vrchat.cloud/api/1/favorites/
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 
@@ -38,9 +38,9 @@ tags | array | Is only 1 string value that is the name of the favorite group
 
 ## Misc
 
-Some other ways to get specific favorite types without the /favorites endpoint.  
-Why these exist? No idea, they are sorta redundant  
-Note that these return the same way as the endpoint above, and take the same parameters (besides type)  
+Some other ways to get specific favorite types without the /favorites endpoint.
+Why these exist? No idea, they are sorta redundant
+Note that these return the same way as the endpoint above, and take the same parameters (besides type)
 
 https://api.vrchat.cloud/api/1/worlds/favorites - Favorite worlds
 https://api.vrchat.cloud/api/1/auth/user/friends/favorite - Favorite friends

--- a/FeedbackAPI/GetWorldFeedback.md
+++ b/FeedbackAPI/GetWorldFeedback.md
@@ -15,7 +15,7 @@ WORLDID - The world id you want to fetch info about
 WORLDREVISION - The revision of the world you want to fetch info about.
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/FileAPI/CreateFile.md
+++ b/FileAPI/CreateFile.md
@@ -11,7 +11,7 @@ POST
 https://api.vrchat.cloud/api/1/file
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 

--- a/FileAPI/CreateNewVersion.md
+++ b/FileAPI/CreateNewVersion.md
@@ -44,7 +44,7 @@ fileMd5 | base64 string | file md5 checksum
 fileSizeInBytes | long | file size in bytes
 
 ## Requires Authentication
-Yes  (See [here](Authorization.md) for details)
+Yes  (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/FileAPI/DeleteFile.md
+++ b/FileAPI/DeleteFile.md
@@ -13,7 +13,7 @@ https://api.vrchat.cloud/api/1/file/[FILEID]
 FILEID - the file id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/FileAPI/FinishUpload.md
+++ b/FileAPI/FinishUpload.md
@@ -21,6 +21,6 @@ type - the file type
     - signature
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns

--- a/FileAPI/GetFile.md
+++ b/FileAPI/GetFile.md
@@ -13,7 +13,7 @@ https://api.vrchat.cloud/api/1/file/[FILEID]
 fileId - the file id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/FileAPI/StartUpload.md
+++ b/FileAPI/StartUpload.md
@@ -25,6 +25,6 @@ partNumber - optional, for larger files it allows to do a multiplart upload
     - signature
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns

--- a/FileAPI/UploadStatus.md
+++ b/FileAPI/UploadStatus.md
@@ -11,7 +11,7 @@ GET
 https://api.vrchat.cloud/api/1/file/[ID]/[VERSION]/[TYPE]/status
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 unknown - currently it keep sending back server error

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -48,7 +48,7 @@ Using the auth cookie is recommended, as each call with only the auth header wil
 
 ## Client API Key
 
-Every API requires you to give a special API key. To get it simply call the [Remote Config](SystemAPI/Config.md) endpoint.
+Every API requires you to give a special API key. To get it simply call the [Remote Config](/SystemAPI/Config.md) endpoint.
 
 The API key is passed in a query string named `apiKey`
 

--- a/ModerationAPI/Against.md
+++ b/ModerationAPI/Against.md
@@ -10,7 +10,7 @@ https://api.vrchat.cloud/api/1/auth/user/playermoderated
 
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/ModerationAPI/ClearModerations.md
+++ b/ModerationAPI/ClearModerations.md
@@ -11,7 +11,7 @@ https://api.vrchat.cloud/api/1/user/[ID]/moderations
 ID - the id of the user
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/ModerationAPI/DeleteModeration.md
+++ b/ModerationAPI/DeleteModeration.md
@@ -12,7 +12,7 @@ ID - the id of the user
 MODERATIONID - the id of the moderation to delete
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/ModerationAPI/Players.md
+++ b/ModerationAPI/Players.md
@@ -9,7 +9,7 @@ GET
 https://api.vrchat.cloud/api/1/auth/user/playermoderations
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/ModerationAPI/SendModerations.md
+++ b/ModerationAPI/SendModerations.md
@@ -11,7 +11,7 @@ https://api.vrchat.cloud/api/1/user/[ID]/moderations
 ID - the id of the user
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/ModerationAPI/SendPlayerModerations.md
+++ b/ModerationAPI/SendPlayerModerations.md
@@ -10,7 +10,7 @@ POST
 https://api.vrchat.cloud/api/1/auth/user/blocks
 
 ### Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ### Parameters
 

--- a/NotificationAPI/Delete.md
+++ b/NotificationAPI/Delete.md
@@ -15,8 +15,8 @@ https://api.vrchat.cloud/api/1/auth/user/notifications/[ID]/hide
 id - the notification id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Notification object`](Objects/Notification.md?id=notification-object)
+[`Notification object`](/Objects/Notification.md#notification-object)

--- a/NotificationAPI/GetAll.md
+++ b/NotificationAPI/GetAll.md
@@ -11,7 +11,7 @@ GET
 https://api.vrchat.cloud/api/1/auth/user/notifications
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 
@@ -23,4 +23,4 @@ after | date | Yes | Only return notifications sent after this date
 
 ## Returns
 
-Array of [`Notification objects`](Objects/Notification.md?id=notification-object)
+Array of [`Notification objects`](/Objects/Notification.md#notification-object)

--- a/NotificationAPI/MarkAsSeen.md
+++ b/NotificationAPI/MarkAsSeen.md
@@ -13,8 +13,8 @@ https://api.vrchat.cloud/api/1/auth/user/notifications/[ID]/see
 id - the notification id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Notification object`](Objects/Notification.md?id=notification-object)
+[`Notification object`](/Objects/Notification.md#notification-object)

--- a/NotificationAPI/SendNotification.md
+++ b/NotificationAPI/SendNotification.md
@@ -14,23 +14,23 @@ https://api.vrchat.cloud/api/1/user/[ID]/notification
 id - the user to send notification to
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 
 Field | Type | Optional | Description
 ------|------|----------|------------
-type | [`NotificationType`](Objects/Notification.md?id=notification) | No | The type of notification to send
+type | [`NotificationType`](/Objects/Notification.md#notification) | No | The type of notification to send
 message | string | Yes | The message to send
 details | json as string | Yes | Details for some notifications
 
 ## Returns
 
-[`Notification Object`](Objects/Notification.md?id=notification-object), with the extra key-value pairs below
+[`Notification Object`](/Objects/Notification.md#notification-object), with the extra key-value pairs below
 
 Field | Type | Description
 ------|------|------------
-receiverUserId | [`userId`](Objects/User.md?id=user-object) | ID of the user who will receive the notification
+receiverUserId | [`userId`](/Objects/User.md#user-object) | ID of the user who will receive the notification
 jobName | string | unknown, always `write_notification`
 jobColor | string | unknown, always `blue`
 

--- a/Objects/Avatar.md
+++ b/Objects/Avatar.md
@@ -16,7 +16,7 @@ version | integer | Upload version of avatar
 featured | boolean | If the avatar is featured
 created_at | string | Date and time avatar was first uploaded
 updated_at | string | Date and time avatar was last uploaded
-releaseStatus | [`ReleaseStatus`](Objects/Avatar.md?id=releasestatus) | Release status of avatar
+releaseStatus | [`ReleaseStatus`](/Objects/Avatar.md#releasestatus) | Release status of avatar
 assetUrl | string | Bundled avatar file url (.vrca)
 assetVersion | string | Unknown
 assetUrlObject | JSONArray | Unknown (Returns empty) - Only returns if you are authenticated and own the avatar
@@ -26,7 +26,7 @@ thumbnailImageUrl | string | Small cover image of avatar
 unityVersion | string | Version of unity avatar was upload from
 unityPackageUrl | string | Full unitypackage file that can be used in unity as is (.unitypackage). Looks to be no longer used
 unityPackageUrlObject | JSONArray | Unknown (Returns empty)
-unityPackages | array | Array of [`unityPackage`](Objects/unityPackage.md?id=unitypackage-object) objects
+unityPackages | array | Array of [`unityPackage`](/Objects/unityPackage.md#unitypackage-object) objects
 
 # Special types
 

--- a/Objects/Notification.md
+++ b/Objects/Notification.md
@@ -9,9 +9,9 @@ Key | Type | Description
 id | string | Notification ID of the notification (prefixed with not)
 senderUsername | string | Username of the user that sent the notification
 senderUserId | string | User ID of the user that sent the notification
-type | [`NotificationType`](Objects/Notification.md?id=notification) | Type of notification
+type | [`NotificationType`](/Objects/Notification.md#notification) | Type of notification
 message | string | Probably something to do with a messaging system, is empty for now
-details | [`NotificationDetails`](Objects/Notification.md?id=notificationdetails-objects) | Details about notification (world info, user info, etc)
+details | [`NotificationDetails`](/Objects/Notification.md#notificationdetails-objects) | Details about notification (world info, user info, etc)
 seen | boolean | If current user has seen the notification
 created_at | string | Date and time the notification was sent
 
@@ -25,7 +25,7 @@ There are a few different types of this object, depending on the type of notific
 
 Key | Type | Description
 ----|------|------------
-worldId | [`Location`](Objects/World.md?id=location) | Location the invite is to
+worldId | [`Location`](/Objects/World.md#location) | Location the invite is to
 
 ### requestInvite
 
@@ -37,14 +37,14 @@ platform | string | Platform user who sent the notification is on
 
 Key | Type | Description
 ----|------|------------
-userToKickId | [`userId`](Objects/User?id=user-object) | ID of the user to kick
-initiatorUserId | [`userId`](Objects/User?id=user-object) | ID of the user who started vote
+userToKickId | [`userId`](/Objects/User#user-object) | ID of the user to kick
+initiatorUserId | [`userId`](/Objects/User#user-object) | ID of the user who started vote
 
 ### halp
 
 Key | Type | Description
 ----|------|------------
-halpId | [`worldId`](Objects/World?id=limited-world-object) | ID of world
+halpId | [`worldId`](/Objects/World#limited-world-object) | ID of world
 
 # Special types
 

--- a/Objects/User.md
+++ b/Objects/User.md
@@ -10,7 +10,7 @@ Key | Type | Description
 ----|------|------------
 username | string | Users username (displayName, but lowercase)
 displayName | string | Users display name
-pastDisplayNames | array | Array of [`PastDisplayName`](Objects/User.md?id=pastdisplayname) objects
+pastDisplayNames | array | Array of [`PastDisplayName`](/Objects/User.md#pastdisplayname) objects
 id | string | User ID of user (Usually prefixed by "usr", except in some rare cases)
 bio | string | Bio of user
 bioLinks | array | Array of URLs (strings) user has added to their account
@@ -30,8 +30,8 @@ onlineFriends | array | Array of online friend User IDs
 activeFriends | array | Array of active friend User IDs
 offlineFriends | array | Array of offline friend User IDs
 friendGroupNames | array | Array of names (strings) of groups user has made
-state | [`State`](Objects/User.md?id=state) | Current state of user, only returns if isFriend is true
-status | [`Status`](Objects/User.md?id=status) | Current status of user, only returns if isFriend is true
+state | [`State`](/Objects/User.md#state) | Current state of user, only returns if isFriend is true
+status | [`Status`](/Objects/User.md#status) | Current status of user, only returns if isFriend is true
 statusDescription | string | Custom status message of user
 currentAvatar | string | Avatar ID of current avatar
 currentAvatarAssetUrl | string | Url to bundled avatar file (.vrca)
@@ -46,8 +46,8 @@ allowAvatarCopying | boolean | If user has allowed cloning of public avatars the
 accountDeletionDate | string/null | Either date and time account will be deleted or date and time account was deleted. Returns null type when none
 unsubscribe | boolean | If user has unsubscribed from VRChat general emails
 tags | array | Array of strings, defining certain settings and accessibility user has
-feature | [`Feature`](Objects/User.md?id=feature) | Probably current 'features' and if the user has access to them
-developerType | [`DeveloperType`](Objects/User.md?id=developertype) | Type of developer user is
+feature | [`Feature`](/Objects/User.md#feature) | Probably current 'features' and if the user has access to them
+developerType | [`DeveloperType`](/Objects/User.md#developertype) | Type of developer user is
 isFriend | boolean | If the user is a friend of current user (who got this object in response)
 friendKey | string | Key that probably identifies you as their friend if you have it, or an empty string if isFriend is false
 
@@ -60,8 +60,8 @@ displayName | string | Users display name
 id | string | User ID of user (Usually prefixed by "usr", except in some rare cases)
 bio | string | Bio of user
 bioLinks | array | Array of URLs (strings) user has added to their account
-state | [`State`](Objects/User.md?id=state) | Current state of user, only returns if isFriend is true
-status | [`Status`](Objects/User.md?id=status) | Current status of user, only returns if isFriend is true
+state | [`State`](/Objects/User.md#state) | Current state of user, only returns if isFriend is true
+status | [`Status`](/Objects/User.md#status) | Current status of user, only returns if isFriend is true
 statusDescription | string | Custom status message of user
 currentAvatarImageUrl | string | Cover image of user's current avatar
 currentAvatarThumbnailImageUrl | string | Small cover image of user's current avatar
@@ -69,12 +69,12 @@ last_login | string | Time and date user last logged in
 last_platform | string | Last platform of VRChat that user logged in from
 allowAvatarCopying | boolean | If user has allowed cloning of public avatars they are using
 tags | array | Array of strings, defining certain settings and accessibility user has
-developerType | [`DeveloperType`](Objects/User.md?id=developertype) | Type of developer user is
+developerType | [`DeveloperType`](/Objects/User.md#developertype) | Type of developer user is
 isFriend | boolean | If the user is a friend of current user (who got this object in response)
 friendKey | string | Key that probably identifies you as their friend if you have it, or an empty string if isFriend is false
-location | [`Location`](Objects/World.md?id=location) | Type of instance user is in. Offline if user is offline or an empty string if isFriend is false
+location | [`Location`](/Objects/World.md#location) | Type of instance user is in. Offline if user is offline or an empty string if isFriend is false
 worldId | string | World ID of world user is in, offline if user is offline or empty string if isFriend is false
-instanceId | [`Location`](Objects/World.md?id=location) | Instance location with no worldId (combination of instanceName, [`instanceType`](Objects/World.md?id=instance-type) and [`nonce`](Objects/World.md?id=nonce)). Offline if user is offline or empty string if isFriend is false.
+instanceId | [`Location`](/Objects/World.md#location) | Instance location with no worldId (combination of instanceName, [`instanceType`](/Objects/World.md#instance-type) and [`nonce`](/Objects/World.md#nonce)). Offline if user is offline or empty string if isFriend is false.
 
 ## Limited User object
 
@@ -84,14 +84,14 @@ username | string | Users username (displayName, but lowercase)
 displayName | string | Users display name
 id | string | User ID of user (Usually prefixed by "usr", except in some rare cases)
 bio | string | Bio of user, set on the VRChat website
-status | [`Status`](Objects/User.md?id=status) | Current status of user, only returns if isFriend is true
+status | [`Status`](/Objects/User.md#status) | Current status of user, only returns if isFriend is true
 currentAvatarImageUrl | string | Cover image of user's current avatar
 currentAvatarThumbnailImageUrl | string | Small cover image of user's current avatar
 last_platform | string | Last platform of VRChat that user logged in from
 tags | array | Array of strings, defining certain settings and accessibility user has
-developerType | [`DeveloperType`](Objects/User.md?id=developertype) | Type of developer user is
+developerType | [`DeveloperType`](/Objects/User.md#developertype) | Type of developer user is
 isFriend | boolean | If the user is a friend of current user (who got this object in response)
-location | [`Location`](Objects/World.md?id=location) | Type of instance user is in. Offline if user is offline or an empty string if isFriend is false
+location | [`Location`](/Objects/World.md#location) | Type of instance user is in. Offline if user is offline or an empty string if isFriend is false
 
 ## Feature
 

--- a/Objects/World.md
+++ b/Objects/World.md
@@ -18,7 +18,7 @@ version | integer | Upload version of world
 featured | boolean | If world is featured or not
 created_at | string | Time and date world was first uploaded
 updated_at | string | Time and date world was last uploaded
-releaseStatus | [`ReleaseStatus`](Objects/World.md?id=releasestatus-type) | Release status of world
+releaseStatus | [`ReleaseStatus`](/Objects/World.md#releasestatus-type) | Release status of world
 visits | integer | Times world has been visited
 publicOccupants | integer | Current users in public instances of this world
 privateOccupants | integer | Current users in private instances of this world
@@ -33,7 +33,7 @@ thumbnailImageUrl | string | Small cover image of world
 organization | string | Unknown
 heat | integer | Unknown (Looks to be connected to popularity somehow)
 namespace | string | Unknown
-instances | array | Array of [`Instance`](Objects/World.md?id=instance-type)s
+instances | array | Array of [`Instance`](/Objects/World.md#instance-type)
 previewYoutubeId | null (?) | Probably something to do with a youtube id for a video that previews a world. Doesn't look to be used currently
 publicationDate | string | Time and date world was made public, or 'none'
 labsPublicationDate | string | Time and date world was made public using the community labs system, or 'none'
@@ -41,7 +41,7 @@ pluginUrl | string | URL (usually DLL). This is probably used for custom scripts
 pluginUrlObject | JSONArray | Unknown (Always empty)
 unityPackageUrl | string | Full unitypackage file that can be used in unity as is (.unitypackage). Looks to be no longer used
 unityPackageUrlObject | JSONArray | Unknown (Always empty)
-unityPackages | array | Array of [`unityPackage`](Objects/unityPackage.md?id=unitypackage-object) objects (Probably different variants of the world)
+unityPackages | array | Array of [`unityPackage`](/Objects/unityPackage.md#unitypackage-object) objects (Probably different variants of the world)
 
 ## Limited World object
 
@@ -54,7 +54,7 @@ authorId | integer | User ID of user who created world
 tags | array | Array of world tags (strings) defined by world creator, system and admins
 created_at | string | Time and date world was first uploaded
 updated_at | string | Time and date world was last uploaded
-releaseStatus | [`ReleaseStatus`](Objects/World.md?id=releasestatus-type) | Release status of world
+releaseStatus | [`ReleaseStatus`](/Objects/World.md#releasestatus-type) | Release status of world
 visits | integer | Times world has been visited
 occupants | integer | Current people in instances of this world
 capacity | integer | User capacity for instances of this world
@@ -66,22 +66,22 @@ organization | string | Unknown
 heat | integer | Unknown (Looks to be connected to popularity somehow)
 publicationDate | string | Time and date world was made public, or 'none'
 labsPublicationDate | string | Time and date world was made public using the community labs system, or 'none'
-unityPackages | array | Array of [`unityPackage`](Objects/unityPackage.md?id=unitypackage-object) objects (Probably different variants of the world)
+unityPackages | array | Array of [`unityPackage`](/Objects/unityPackage.md#unitypackage-object) objects (Probably different variants of the world)
 
 ## Instance object
 
 Key | Type | Description
 ----|------|------------
 name | string | Number identifier
-id | [`location`](Objects/World.md?id=location) | Instance location (combination of worldId, instanceName, [`instanceType`](Objects/World.md?id=instance-type) and [`nonce`](Objects/World.md?id=nonce))
-type | [`instance type`](Objects/World.md?id=instance-type) | Type of instance
+id | [`location`](/Objects/World.md#location) | Instance location (combination of worldId, instanceName, [`instanceType`](/Objects/World.md#instance-type) and [`nonce`](/Objects/World.md#nonce))
+type | [`instance type`](/Objects/World.md#instance-type) | Type of instance
 active | boolean | If the world is "active" (used often)
 n_users | integer | Number of users in the instance
 capacity | integer | Maximum number of users that can be in the instance
 full | boolean | If the n_users is equal to capacity
 canRequstInvite | boolean | Probably if users can ask to be invited to this instance
-location | [`location`](Objects/World.md?id=location) | Instance location (combination of worldId, instanceName, [`instanceType`](Objects/World.md?id=instance-type) and [`nonce`](Objects/World.md?id=nonce))
-instanceId | [`location`](Objects/World.md?id=location) | Instance location with no worldId (combination of instanceName, [`instanceType`](Objects/World.md?id=instance-type) and [`nonce`](Objects/World.md?id=nonce))
+location | [`location`](/Objects/World.md#location) | Instance location (combination of worldId, instanceName, [`instanceType`](/Objects/World.md#instance-type) and [`nonce`](/Objects/World.md#nonce))
+instanceId | [`location`](/Objects/World.md#location) | Instance location with no worldId (combination of instanceName, [`instanceType`](/Objects/World.md#instance-type) and [`nonce`](/Objects/World.md#nonce))
 shortName | string | Shorter name used to share instance url (https://vrchat.com/i/shortName)
 ownerId | string | Either userId of the instance master, or userId of connecting user to non-public instance
 worldId | string | World ID of the world

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ https://discord.gg/rj3YQQu #vrchat-api
 # Getting Started
 
 Now that you've read the information you should be ready to get started.
-[Getting Started](GettingStarted.md)
+[Getting Started](/GettingStarted.md)

--- a/SystemAPI/Auth.md
+++ b/SystemAPI/Auth.md
@@ -9,7 +9,7 @@ GET
 https://api.vrchat.cloud/api/1/auth
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details), must be with auth cookie!
+Yes (See [here](/Authorization.md) for details), must be with auth cookie!
 
 ## Returns
 

--- a/UserAPI/AcceptIgnoreFriend.md
+++ b/UserAPI/AcceptIgnoreFriend.md
@@ -2,9 +2,9 @@
 
 !> The endpoint details should probably be moved to the Notification API section. but I am not sure if the accept is only used for friendRequest or other types as well
 
-Friend requests can be found using the Notification API when the [Get All Notifications](NotificationAPI/GetAll.md) endpoints using `friendRequest` for the notification type filter.
+Friend requests can be found using the Notification API when the [Get All Notifications](/NotificationAPI/GetAll.md) endpoints using `friendRequest` for the notification type filter.
 
-To ignore a Friend Request simply use the [Delete Notification](NotificationAPI/Delete.md).
+To ignore a Friend Request simply use the [Delete Notification](/NotificationAPI/Delete.md).
 
 To accept use the following endpoint
 
@@ -17,7 +17,7 @@ https://api.vrchat.cloud/api/1/auth/user/notifications/[ID]/accept
 id - the id of the friend notification
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/UserAPI/CurrentUserDetails.md
+++ b/UserAPI/CurrentUserDetails.md
@@ -11,8 +11,8 @@ GET
 https://api.vrchat.cloud/api/1/auth/user
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Current User object`](Objects/User.md?id=current-user-object)
+[`Current User object`](/Objects/User.md#current-user-object)

--- a/UserAPI/Delete.md
+++ b/UserAPI/Delete.md
@@ -10,8 +10,8 @@ PUT
     https://api.vrchat.cloud/api/1/user/[ID]/delete
 
 ## Requires Authentication
-No (See [here](Authorization.md) for details)
+No (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Current User object`](Objects/User.md?id=current-user-object)
+[`Current User object`](/Objects/User.md#current-user-object)

--- a/UserAPI/FriendRequest.md
+++ b/UserAPI/FriendRequest.md
@@ -13,8 +13,8 @@ POST
 id - the id of the user to send friend request
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-A [notification](NotificationAPI/SendNotification.md) info. but the type is always `friendRequest`
+A [notification](/NotificationAPI/SendNotification.md) info. but the type is always `friendRequest`

--- a/UserAPI/FriendStatus.md
+++ b/UserAPI/FriendStatus.md
@@ -11,7 +11,7 @@ GET
 id - the id of the user to get status for
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/UserAPI/Friends.md
+++ b/UserAPI/Friends.md
@@ -11,7 +11,7 @@ All: https://api.vrchat.cloud/api/1/auth/user/friends
 Favorite (Beta): https://api.vrchat.cloud/api/1/auth/user/friends/favorite
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 
@@ -23,4 +23,4 @@ offline | boolean | Yes | Should return offline friends
 
 ## Returns
 
-Array of [`Limited User objects`](Objects/User.md?id=limited-user-object)
+Array of [`Limited User objects`](/Objects/User.md#limited-user-object)

--- a/UserAPI/GetByID.md
+++ b/UserAPI/GetByID.md
@@ -11,9 +11,9 @@ GET
 id - the user id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 
 ## Returns
 
-[`User object`](Objects/User.md?id=user-object)
+[`User object`](/Objects/User.md#user-object)

--- a/UserAPI/GetByName.md
+++ b/UserAPI/GetByName.md
@@ -11,9 +11,9 @@ GET
 USERNAME - the user 's ingame name
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 
 ## Returns
 
-[`User object`](Objects/User.md?id=user-object)
+[`User object`](/Objects/User.md#user-object)

--- a/UserAPI/List.md
+++ b/UserAPI/List.md
@@ -13,7 +13,7 @@ Active only
     https://api.vrchat.cloud/api/1/users/active
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 # Parameter
 
@@ -26,4 +26,4 @@ offset | int | yes | How many users to skip
 
 ## Returns
 
-Array of [`Limited User objects`](Objects/User.md?id=limited-user-object)
+Array of [`Limited User objects`](/Objects/User.md#limited-user-object)

--- a/UserAPI/Login.md
+++ b/UserAPI/Login.md
@@ -9,8 +9,8 @@ GET
     https://api.vrchat.cloud/api/1/auth/user
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Current User object`](Objects/User.md?id=current-user-object)
+[`Current User object`](/Objects/User.md#current-user-object)

--- a/UserAPI/Logout.md
+++ b/UserAPI/Logout.md
@@ -10,4 +10,4 @@ PUT
     https://api.vrchat.cloud/api/1/logout
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)

--- a/UserAPI/Register.md
+++ b/UserAPI/Register.md
@@ -27,4 +27,4 @@ acceptedTOSVersion | string | Yes | Accepted ToS version (Current is ToS version
 
 ## Returns
 
-[`Current User object`](Objects/User.md?id=current-user-object)
+[`Current User object`](/Objects/User.md#current-user-object)

--- a/UserAPI/ResendEmail.md
+++ b/UserAPI/ResendEmail.md
@@ -9,4 +9,4 @@ POST
     https://api.vrchat.cloud/api/1/auth/user/resendEmail
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)

--- a/UserAPI/Steam.md
+++ b/UserAPI/Steam.md
@@ -19,6 +19,6 @@ steamTicket | string | No | The Steamworks ticket from the VRChat game
 
 ## Returns
 
-[`Current User object`](Objects/User.md?id=current-user-object)
+[`Current User object`](/Objects/User.md#current-user-object)
 
 The endpoint also return an auth cookie that can be used until the socket is disconnected from the web server

--- a/UserAPI/Unfriend.md
+++ b/UserAPI/Unfriend.md
@@ -13,7 +13,7 @@ DELETE
 id - the id of the user to unfriend
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/UserAPI/UpdateInfo.md
+++ b/UserAPI/UpdateInfo.md
@@ -13,7 +13,7 @@ PUT
 id - The current user id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 
@@ -38,4 +38,4 @@ bioLinks | Array | yes | Links.
 
 ## Returns
 
-[`Current User object`](Objects/User.md?id=current-user-object)
+[`Current User object`](/Objects/User.md#current-user-object)

--- a/UserAPI/Verify.md
+++ b/UserAPI/Verify.md
@@ -6,11 +6,11 @@ Finishes the login sequence for accounts with 2FactorAuth
 POST
 
 ## Endpoint
-https://api.vrchat.cloud/api/1/auth/twofactorauth/totp/verify For Two-Factor-Auth codes  
+https://api.vrchat.cloud/api/1/auth/twofactorauth/totp/verify For Two-Factor-Auth codes
 https://api.vrchat.cloud/api/1/auth/twofactorauth/otp/verify For recovery codes
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Request requirements
 

--- a/WorldAPI/DeleteWorld.md
+++ b/WorldAPI/DeleteWorld.md
@@ -13,11 +13,11 @@ DELETE
 id - the world's id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`World object`](Objects/World.md?id=world-object)
+[`World object`](/Objects/World.md#world-object)
 
 *** The returned world object does NOT have these 5 keys ***
 

--- a/WorldAPI/GetInstance.md
+++ b/WorldAPI/GetInstance.md
@@ -10,11 +10,11 @@ GET
 
 id - the world id
 
-instanceid - "instanceName" followed by [`Location type`](Objects/User.md?id=instance-type) and [`Nonce`](Objects/User.md?id=nonce) (if applicable)
+instanceid - "instanceName" followed by [`Location type`](/Objects/User.md#instance-type) and [`Nonce`](/Objects/User.md#nonce) (if applicable)
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`Instance object`](Objects/World.md?id=instance-object)
+[`Instance object`](/Objects/World.md#instance-object)

--- a/WorldAPI/GetMetadata.md
+++ b/WorldAPI/GetMetadata.md
@@ -12,7 +12,7 @@ https://api.vrchat.cloud/api/1/worlds/[ID]/metadata
 id - the world id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 

--- a/WorldAPI/GetWorld.md
+++ b/WorldAPI/GetWorld.md
@@ -11,8 +11,8 @@ https://api.vrchat.cloud/api/1/worlds/[ID]
 id - the world id
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Returns
 
-[`World object`](Objects/World.md?id=world-object)
+[`World object`](/Objects/World.md#world-object)

--- a/WorldAPI/ListWorlds.md
+++ b/WorldAPI/ListWorlds.md
@@ -22,7 +22,7 @@ Only Favorite Worlds:
 
 
 ## Requires Authentication
-Yes (See [here](Authorization.md) for details)
+Yes (See [here](/Authorization.md) for details)
 
 ## Parameters
 
@@ -66,4 +66,4 @@ Trending is set as:
 
 ## Returns
 
-Array of [`Limited World objects`](Objects/World.md?id=limited-world-object)
+Array of [`Limited World objects`](/Objects/World.md#limited-world-object)


### PR DESCRIPTION
Makes links absolute to root of repo and use # instead of ?id= to work in the repo, docsify handles this conversion for Pages