### PR TITLE
Removed non-existent "beta-api" endpoint from docs

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -26,8 +26,7 @@ Sections labeled **BETA** are API endpoints found in the beta client of VRChat, 
 Right now there are 3 different options
 
 1. Dev API - https://dev-api.vrchat.cloud/api/1/ (Not Documented)
-2. Beta API - https://beta-api.vrchat.cloud/api/1/ (Not Documented)
-3. Release API - https://api.vrchat.cloud/api/1/
+2. Release API - https://api.vrchat.cloud/api/1/
 
 In the docs we just use the Release but you can manually change it if needed
 

--- a/kor/GettingStarted.md
+++ b/kor/GettingStarted.md
@@ -23,8 +23,7 @@
 지금은 3가지 선택지가 있습니다.
 
 1. Dev API - https://dev-api.vrchat.cloud/api/1/ (문서화 되지 않음)
-2. Beta API - https://beta-api.vrchat.cloud/api/1/ (문서화 되지 않음)
-3. Release API - https://api.vrchat.cloud/api/1/
+2. Release API - https://api.vrchat.cloud/api/1/
 
 이 문서에서 저희는 그냥 릴리즈를 사용하지만, 필요에 따라 당신이 직접 변경할 수 도 있습니다.
 


### PR DESCRIPTION
This seems to never have existed, only somehow mentioned in code. They haven't even configured Cloudflare DNS records for this domain.