### PR TITLE
Restore OAuth documentation 

### DIFF
--- a/OAuthAPI/CreateOAuthApplication.md
+++ b/OAuthAPI/CreateOAuthApplication.md
@@ -1,0 +1,26 @@
+# Create Oauth Application
+
+This API allows you to create Oauth Application, requries moderator/internal developerType or admin_moderator tag.
+
+## Request Method 
+POST
+
+## Endpoint
+https://api.vrchat.cloud/api/1/oauth
+
+## Requires Authentication
+Yes
+
+## Parameters 
+
+Field | Type | Description
+------|------|------------
+name | string | Application name
+company | string | Company name
+endpoint | string | Return point on successful user authorization
+scopes | string | Scopes application
+secret | string | Secret key
+thumbnail | string | Application thumbnail
+
+## Return
+???

--- a/OAuthAPI/GetOAuthApplication.md
+++ b/OAuthAPI/GetOAuthApplication.md
@@ -1,0 +1,25 @@
+# Get Oauth Application
+
+This API allows you to get information about a Oauth application.
+
+## Request Method 
+GET
+
+## Endpoint
+https://api.vrchat.cloud/api/1/oauth/[ID]
+
+id - the application id
+
+## Requires Authentication
+Yes
+
+## Returns 
+
+Field | Type | Description
+------|------|------------
+id | string | Application id
+company | string | Сompany name
+name | string | Application name
+endpoint | string | Return point on successful user authorization
+scopes | object | Scopes application
+thumbnail | string | Application thumbnail


### PR DESCRIPTION
Initially added in this commit:
https://github.com/vrchatapi/vrchatapi.github.io/commit/e2c8bb15b605010fd7148c7664178238ed0c0375

And then later subsequently deleted without explanation in this commit:
https://github.com/vrchatapi/vrchatapi.github.io/commit/363ced7424eaf208308b5ee4e574389b026acd0a

The GET endpoint has been verified to be working, POC:
https://api.vrchat.cloud/api/1/oauth/oauth_b9260015-6ba7-4eff-837b-5e6f13bee436