### PR TITLE
Cleaned up Tags documentation

### DIFF
--- a/UserAPI/Tags.md
+++ b/UserAPI/Tags.md
@@ -9,16 +9,12 @@ Name | Permission
 `admin_scripting_access` and `system_scripting_access` | has scripting access (can upload user made scripts)
 `system_avatar_access` and `admin_avatar_access` | Can publish avatars
 `system_world_access` and `admin_world_access` | Can publish worlds
-`admin_avatar_restricted` | Unknown
-`admin_world_restricted` | Unknown
 `admin_moderator` | VRChat Staff, has moderator permissions (moderators usually do not have this one to cover their identity)
 `system_feedback_access` | User can send Feedback
 `system_probable_troll` | Probably been reported multiple times and is (probably) a troll
 `system_troll` | User is a confirmed troll
 `system_supporter` | User has an active VRC+ subscription
 `system_early_adopter` | User bought VRC+ in the early period of when it came out
-`admin_lock_level` | The users level is locked by staff and will not progress up in rank
-`admin_lock_tags` | Tags are locked and cannot be added nor removed
 `admin_official_thumbnail` | Replaces the users profile picture with the VRChat logo
 `show_social_rank` | Show trust rank
 `system_UE4_dev_access` | Meaningless tag used by Tupper

--- a/UserAPI/Tags.md
+++ b/UserAPI/Tags.md
@@ -1,35 +1,34 @@
 # Tags
 
-Tags are way to add users different access and abilities
+Tags are way to grant various access, abilities or assign restrictions to a user.
+
+System tags starting with `system_` are granted automatically by the system, while admin tags with `admin_` are granted manually.
 
 Name | Permission
 -----|-----------
 `admin_scripting_access` and `system_scripting_access` | has scripting access (can upload user made scripts)
-`system_avatar_access` | can publish avatars
-`system_world_access` | can publish worlds
-`admin_avatar_access` | unknown how different from `system_avatar_access`
-`admin_world_access` | unknown how different from `system_world_access`
-`admin_avatar_restricted` | unknown
-`admin_world_restricted` | unknown
-`admin_moderator` | moderator trust level
-`system_feedback_access` | can send feedback
-`system_trust_known` | unknown
-`system_trust_basic` and `system_trust_trusted`| basic trust level
-`system_trust_intermediate` and `system_trust_veteran`| intermediate trust level
-`system_legend` and `system_trust_legend`| Probably means the user spends alot of time in the game
+`system_avatar_access` and `admin_avatar_access` | Can publish avatars
+`system_world_access` and `admin_world_access` | Can publish worlds
+`admin_avatar_restricted` | Unknown
+`admin_world_restricted` | Unknown
+`admin_moderator` | VRChat Staff, has moderator permissions (moderators usually do not have this one to cover their identity)
+`system_feedback_access` | User can send Feedback
 `system_probable_troll` | Probably been reported multiple times and is (probably) a troll
-`system_troll` | Probably confirmed troll.
-`system_supporter` | has an active VRChat Plus subscription
-`system_early_adopter` | Probably means something similar to "VRChat Plus Early Explorer"
-`admin_lock_level` | unknown
-`admin_lock_tags` | Probably stops system from adding and removing tags
-`admin_official_thumbnail` | Replace avatarimage with vrchat logo
+`system_troll` | User is a confirmed troll
+`system_supporter` | User has an active VRC+ subscription
+`system_early_adopter` | User bought VRC+ in the early period of when it came out
+`admin_lock_level` | The users level is locked by staff and will not progress up in rank
+`admin_lock_tags` | Tags are locked and cannot be added nor removed
+`admin_official_thumbnail` | Replaces the users profile picture with the VRChat logo
 `show_social_rank` | Show trust rank
-`system_UE4_dev_access` | meaningless tag used by tupper
-`system_neuralink_beta` | meaningless tag used by tupper
-`system_extremely_cool_guy` | meaningless tag used by tupper
-`system_stop_being_nosy` | meaningless tag used by tupper
-`system_notamod` | meaningless tag used by tupper
+`system_UE4_dev_access` | Meaningless tag used by Tupper
+`system_neuralink_beta` | Meaningless tag used by Tupper
+`system_extremely_cool_guy` | Meaningless tag used by Tupper
+`system_stop_being_nosy` | Meaningless tag used by Tupper
+`system_notamod` | Meaningless tag used by Tupper
+`system_no_seriously_im_not_a_mod_how_many_times_do_i_have_to_tell_people` | Meaningless tag used by Tupper
+`system_the_tag_is_just_named_that` | Meaningless tag used by Tupper
+`system_haha_you_have_to_document_this_one_too` | Meaningless tag used by Tupper
 
 
 ## Trust Levels
@@ -43,3 +42,4 @@ system_trust_known|User
 system_trust_trusted|Known User
 system_trust_veteran|Trusted User
 system_trust_legend|Veteran User (Unused)
+system_legend|Legendary User (Unused, can no longer be achieved)


### PR DESCRIPTION
Fixed capitalization and expanded description on most tags.

Added more meaningless tags Tupper has created again.

Included "Legendary User" in Trust Levels table due to VRCX displaying this information, and good to clear up to users the difference between system_trust_legend and system_legend.

Removed trust ranks from the primary tags table due to duplicated information, as they are displayed below.

Removed tags which either have never existed or at least doesn't exist anymore.