### PR TITLE
Replace Disqus with Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As stated, this documentation was not created with the help of the official VRCh
 
 # Get in touch with us!
 
-https://discord.gg/rj3YQQu #vrchat-api
+https://discord.gg/qjZE9C9fkB #vrchat-api
 
 # Getting Started
 

--- a/index.html
+++ b/index.html
@@ -36,19 +36,19 @@
       name: "VRChat API Documentation",
       search: {
         placeholder: "Type to search",
-        noData: "No Results Found!",
+        noData: "No results",
         depth: 3
       },
       topBanner: {
-        content: ":wave: Contribute to the documentation via [GitHub](https://github.com/vrchatapi/vrchatapi.github.io) or [Discord](https://discord.gg/rj3YQQu)",
+        content: ":wave: Contribute to the documentation via [GitHub](https://github.com/vrchatapi/vrchatapi.github.io) or [Discord](https://discord.gg/qjZE9C9fkB)",
         position: "relative",
         backgroundColor: "transparent"
       },
       footer: {
         copy: '\
-          <div style="background-color: #7289DA !important; padding: 1rem; font-size: 2rem; font-weight: 900; border-radius: 25px; text-align: center; margin-bottom: 1rem;"> \
+          <div style="background-color: #7289DA !important; padding: 1rem; font-size: 2rem; font-weight: 900; text-align: center; margin-bottom: 1rem;"> \
             <a href="https://discord.gg/qjZE9C9fkB" target="_blank" style="color: #FFF !important; text-decoration: none;"> \
-              <span>Get in touch with us! Join</span>\
+              <span>Get in touch with us!</span>\
               <img height="75px" src="https://discord.com/assets/192cb9459cbc0f9e73e2591b700f1857.svg" style="vertical-align: middle;"> \
             </a> \
           </div>',

--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
       executeScript: true,
       maxLevel: 1,
       name: "VRChat API Documentation",
-      disqus: 'vrchat',
       search: {
         placeholder: "Type to search",
         noData: "No Results Found!",
@@ -45,12 +44,23 @@
         position: "relative",
         backgroundColor: "transparent"
       },
+      footer: {
+        copy: '\
+          <div style="background-color: #7289DA !important; padding: 1rem; font-size: 2rem; font-weight: 900; border-radius: 25px; text-align: center; margin-bottom: 1rem;"> \
+            <a href="https://discord.gg/qjZE9C9fkB" target="_blank" style="color: #FFF !important; text-decoration: none;"> \
+              <span>Get in touch with us! Join</span>\
+              <img height="75px" src="https://discord.com/assets/192cb9459cbc0f9e73e2591b700f1857.svg" style="vertical-align: middle;"> \
+            </a> \
+          </div>',
+        pre: '<hr/>',
+        style: 'text-align: right;',
+      },
     }
   </script>
   
   <script src="https://cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsify-top-banner-plugin@latest/dist/index.js"></script>
-  <script src="//unpkg.com/docsify/lib/plugins/disqus.min.js"></script>
   <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
+  <script src="//unpkg.com/docsify-footer-enh/dist/docsify-footer-enh.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
* Removes DISQUS integration in favour of hinting users to join the Discord. The comment field per page is not used at all and only makes the website look unprofessional (especially the "What did you think of this? React with an emoji!"). And even **if** someone used it then it would need to be moderated, and I'm sure much better support would possible to give on Discord instead.

* Replaced invite link with a permanent link which goes to **directly** to `#vrchat-api` rather than the general channel, reducing effort for the end user.

Feedback on wording and design appreciated.