### PR TITLE
Why Legendary might not be a rank after all

### DIFF
--- a/UserAPI/Tags.md
+++ b/UserAPI/Tags.md
@@ -15,6 +15,7 @@ Name | Permission
 `system_troll` | User is a confirmed troll
 `system_supporter` | User has an active VRC+ subscription
 `system_early_adopter` | User bought VRC+ in the early period of when it came out
+`system_legend` | User is an Experienced player and was active before Summer 2018 (can no longer be achieved)
 `admin_official_thumbnail` | Replaces the users profile picture with the VRChat logo
 `show_social_rank` | Show trust rank
 `system_UE4_dev_access` | Meaningless tag used by Tupper
@@ -38,4 +39,3 @@ system_trust_known|User
 system_trust_trusted|Known User
 system_trust_veteran|Trusted User
 system_trust_legend|Veteran User (Unused)
-system_legend|Legendary User (Unused, can no longer be achieved)


### PR DESCRIPTION
# Why Legendary might not be a rank after all

*This Merge Request is written in the form of a write-up, so it can be potentially linked to as a one-stop explainer.*

Let’s have a talk about the “Legendary Rank”, and the overall functioning of the Trust system on the public API side. In this post I will...
1. Give a brief overview what the Trust system is and importantly how it is represented in the API. If you feel you have a confident understanding of [Tags](https://vrchatapi.github.io/#/UserAPI/Tags) then you can skip the "Background" chapter.
2. Talk about recent findings in regard to various trust theories and where the rumor evolved from.
3. Attempt some sort of "wrap-up" of why things aren't as we have thought them to be, and why it is time for a tiny but important change in how the "system_legend" tag is defined.

![TLDR](https://i.imgur.com/GAd1ned.png)

# Chapter 1: Background

## VRChat Safety and Trust System

> The VRChat Trust and Safety system is a new extension of the currently-implemented VRChat Trust system. It is designed to keep users safe from nuisance users using things like screen-space shaders, loud sounds or microphones, visually noisy or malicious particle effects, and other methods that someone may use to detract from your experience in VRChat.

![Original Trust System](https://miro.medium.com/max/1400/1*mOd27DPcXQft3JsQTnW77w.png)

The system was initially released as part of the Open Beta on [September 21st 2018](https://medium.com/@vrchat/vrchat-safety-and-trust-system-4073f05ab602), and was shortly after [revised on September 26th](https://medium.com/@vrchat/vrchat-safety-and-trust-system-changes-and-feedback-a3a9e54ec572) the same year.

We will completely and fully ignore what variables or how the system hands out the regular trust ranks up to Veteran. What we are instead interested in here is how they are represented in the API.

## The Tags System

![Example tags](https://i.imgur.com/dz2kSsK.png)

VRChat has a metadata system in form of [Tags](https://vrchatapi.github.io/#/UserAPI/Tags). Tags are short and simple text strings that can be attached to Worlds, Players, Avatars, Files, Permissions, and more. For example `language_swe` defines that you have the language Swedish on your profile, and `system_supporter` that you have VRC+. Automatically given tags are prefixed with `system_`, admin-related tags with `admin_`, language tags with `language_`, and so on.

![Original Hierarchy](https://i.imgur.com/dBoxDVG.png)

Trust Ranks are prefixed with `system_trust_`, and the higher ones all have an offset by one for the actual in-game role, so `Known User` is `system_trust_trusted`, and `Trusted User` is `system_trust_veteran`.

The `Veteran User` trust rank was later removed in the later revision; the role was hidden in game, and Yellow became the color for Friends. But it is still available and can be achieved by looking at the API. This information is then displayed in 3rd party applications such as [VRCX](https://github.com/pypy-vrc/VRCX).

![Screenshot of a "Veteran User"](https://user-images.githubusercontent.com/25771678/63169787-a810f880-c072-11e9-94fb-af3ed02fa5da.png)

## The mysterious `Legendary` Rank

Although the complete Trust rank doesn't stop at Veteran. In addition to the "Official" rank there is also "VRChat Staff", a title they can toggle in-game, and "Nuisance/Troll", people who have bad enough reputation and will have their Microphone and Avatar turned off by default for everyone.

We finally come to the `"Legendary User"` rank, which is defined by the mysterious `system_legend` tag, and completes the chart of the current public understanding of the Trust Hierarchy.

![Believed Trust Hierarchy](https://i.imgur.com/ZMPggCm.png)

# Chapter 2: Discovery

## The issue that broke the glass

It is now 2021, and the understanding of "Legendary User" as a rank has now stood its time for several years. It all came crashing down recently with an [Bug report to the VRCX project](https://github.com/pypy-vrc/VRCX/issues/232) ("Legendary User rank issues and a possible suggestion") where abbeybabbey had a friend that was Legendary but **not** Veteran. The user had the `system_legend` tag but was missing the `system_trust_legend` tag.

This first anomaly was a living proof that suggested what we believed to be "Legendary Users" is in fact not linearly after Veteran and Trusted. We started looking if we could find more of these examples, and it all went downhill from there.

![A Known User with system_legend tag](https://i.imgur.com/emmoa1k.png)

First off, `BR3UKER`. This person has the `system_legend` tag yet is still only Known User in-game and on the website, missing both `system_trust_legend` and `system_trust_veteran`.

![A NEW USER with system_legend tag](https://i.imgur.com/oSKEqGD.png)

```json
"tags":[
    "system_avatar_access",
    "system_world_access",
    "system_legend",
    "system_trust_basic"
],
```

After finding a few Trusted users, a very interesting person found was "DAZZA_OWN_U", who is **only New User** yet still have the `system_legend` tag. This was a major revelation and ultimately proved that the current understanding had to change.

The major problem here is if you assume `system_legend` to linearly be a rank, and then simply display the highest rank they have, then DAZZA would show up as "Legendary" in VRCX yet only as New User in-game. There would be no easy way to see their real Trust-level without having to go digging in the JSON, so this is a critical information gone missing.

An alternative approach could be to look for a continuous chain of trust ranks starting from the bottom and take the highest one before it breaks, but we also found lots of people who are normal `Trusted Users` but are for some reason missing the `New User` rank. Not everyone seems to be missing it, and we aren't sure why this is the case on some people, so this theory is also in the bin.

## Where did the name `Legendary` come from?

A rumor is contagious like a virus, entertaining like a drug, and eventually can get a life of its own. In the absence of information, and secrecy about the system, we scour for the crumbs, jumping on any detail as a foundation to build further information upon until we eventually build up an information space that we are content with and can accept as plausible. From data we extract an idea, from an idea we extract a theory, and once that theory is believed by enough amount of people it is regarded as truth.

The first ever mention of the `system_legend` tag in the VRChat Discord occurs on the 14th of June 2018, in the #french channel by Slaynash II, 3 months before the Trust system is introduced:

> Au fait @Ruuubick j'aurais une question concernant l'API:
Je comprend à quoi servent les tags "system_avatar_access", "system_world_access" et "system_trust_basic", mais je ne vois pas ce que sont les tags "system_legend", "admin_avatar_access" et "admin_world_access" :thinking:
(et "system_feedback_access" non plus d'ailleurs)

🇫🇷➡️🇬🇧 Translated:

> By the way @Ruuubick I have a question regarding the API:
I understand what the "system_avatar_access", "system_world_access" and "system_trust_basic" tags are for, but I don't see what the "system_legend", "admin_avatar_access" and "admin_world_access" tags are: thinking:
(and "system_feedback_access" either for that matter) 

Also immediately noticeable is that the tag does not follow the same pattern as the other `system_trust_` tags. There are early mentions of `system_legend` being referred to as `Legacy User`, and the first ever mention of "Legendary" in the VRCAPI project was [apparently made by **me**](https://github.com/vrchatapi/vrchatapi.github.io/commit/8276e98c1ad018804eaeb9a5e0b7443a0ade55c7) back in April. In that commit I used VRCX as source; and looking at the commit history of VRCX there are no mentions of when Legendary was first introduced, it simply existed since day one.

Extrapolating from the naming scheme, how `system_trust_veteran` is `Trusted User`, and `system_trust_legend` is `Veteran User`, it is logical by the 1-offset how the next rank in the hierarchy would then naturally be called `Legendary User`, which is the most likely source I could find.

## What could `system_legend` then mean?

Several people made speculations that the `system_legend` tag was granted to people who uploaded content before the Trust System was introduced.

![](https://i.imgur.com/kjNbTFc.png)
![Could system_legend be that you have uploaded content Pre-TrustSystem](https://i.imgur.com/L2ErCBa.png)

After lots of discussion I was ready to write this write-up with the conclusion that this is the *actual* meaning of the tag, until someone last-second mentioned me and told me of a **Steam** user who also has the `system_legend` tag. **WHAT?!**

![A Steam user with system_legend tag](https://i.imgur.com/m5BZuT5.png)

```json
"tags":[
    "system_legend",
    "show_social_rank",
    "system_world_access",
    "system_avatar_access",
    "system_trust_basic",
    "system_feedback_access",
    "system_trust_known",
    "system_trust_trusted",
    "system_trust_veteran",
    "system_trust_legend"
],
```

Even proudly boosting about it in their Bio (and rightly so!!), [H3aven is a Steam account](https://vrchat.com/api/1/users/usr_8dc03fcf-52f1-457d-9e53-ef6d1d7e370f) who again defies all expectations. As there has never been an option in the SDK to log in with Steam and attempting to use an Auth Token derived from a Steam Session Ticket outside of the game results in a `Using a client-derived token outside of client` Error, this makes it impossible for them to have uploaded content, therefore discarding that theory as well. 🗑️🚮

# Chapter 3: Conclusion

## Where does that bring us today?

This has been a long post, but I wanted to properly explain the history and the findings made during what was originally a small bug report but grew into a much bigger and obsessive project which has consumed several days of my time now. 

We know less of this tag today than we thought we did. Its real purpose, and at what exact date people stopped receiving it is something which has yet to be researched.

The only unproven theory remaining alive is the belief that this tag can no longer be acquired, so the people who have it are the only ones who will **ever** have it.

## Time for a change, Goodbye `Legendary`, Hello `Legend`

No matter what its real purpose is, the accounts found above once and for all disproves the old conjecture, that having "Legendary User" rank **does not** implicitly imply that user is also Veteran and Trusted. It is time to discard the notion of "Legendary" as a rank. The possession of this tag is seemingly detached from a user's Trust Rank and should therefore **not** be considered as something part of the modern Trust System.

The best current representation is that of similar status to `system_early_supporter`, a tag given to people who bought VRC+ in the first month of release. It is a tag seemingly given to Experienced players who were playing before the Summer of 2018. It is not given to *all* accounts before this date; but given to players who were active and had done stuff in the game at point of introduction, with the exact requirements remaining unknown.

While those people might indeed be considered "Legendary" in the historic term of how long they have played, it is not something which should shadow their current Trust rank. A better name might therefore be `Long-term User`, `OG User`, `Early Access User` or simply `Legend`, and is something which best should be displayed as a separate badge similarly to VRC+.

![Legend becomes a Tag, not a Trust Rank](https://i.imgur.com/qCWkCwl.png)

I therefore with this Merge Request propose to **partially** [**revert** my previous commit](https://github.com/vrchatapi/vrchatapi.github.io/commit/8276e98c1ad018804eaeb9a5e0b7443a0ade55c7), by **removing mentions of** `Legendary User` and **moving the tag** from the `"Trust Levels"` table to the normal `"Tags"` table.

In reflection of this similar changes are planned to be [introduced in VRCX](https://github.com/pypy-vrc/VRCX/commit/7f2acf69ff1b8d392ea912faa47a5f8a938ef043) as well and is currently under testing.

![A New User with Legend](https://i.imgur.com/rqmIkRU.png)
![A Veteran with Legend](https://i.imgur.com/E6h6Gpy.png)