### PR TITLE
This endpoint does not exist, it was moved to /favourite/ and we have…

### DIFF
--- a/UserAPI/Friends.md
+++ b/UserAPI/Friends.md
@@ -8,8 +8,6 @@ GET
 ## Endpoint
 All: https://api.vrchat.cloud/api/1/auth/user/friends
 
-Favorite (Beta): https://api.vrchat.cloud/api/1/auth/user/friends/favorite
-
 ## Requires Authentication
 Yes (See [here](/GettingStarted/QuickStart?id=authorization) for details)
 


### PR DESCRIPTION
… that documented