### PR TITLE
Archive "Send Notification" endpoint

### DIFF
--- a/Archive/NotificationAPI/SendNotification.md
+++ b/Archive/NotificationAPI/SendNotification.md
@@ -1,3 +1,5 @@
+!> **Archive notice** This endpoint has been restricted. It now always requires Admin Credentials.
+
 # Send Notification
 
 This API allows you to send notifications to other players.

--- a/Archive/UserAPI/ListActive.md
+++ b/Archive/UserAPI/ListActive.md
@@ -1,4 +1,4 @@
-!> **Archive notice** This endpoint was restricted sometime in first half of 2021. This now requires Admin Credentials.
+!> **Archive notice** This endpoint was restricted sometime in first half of 2021. It now always requires Admin Credentials.
 
 # Search Active
 

--- a/index.html
+++ b/index.html
@@ -57,8 +57,9 @@
     const redirects = [
       ["#", "#/README"],
       ["", "#/README"],
-      ["#/ModerationAPI/Against", "#/Archive/ModerationAPI/Against"],
       ["#/GettingStarted", "#/GettingStarted/QuickStart"],
+      ["#/ModerationAPI/Against", "#/Archive/ModerationAPI/Against"],
+      ["#/NotificationAPI/SendNotification", "#/Archive/NotificationAPI/SendNotification"],
     ];
     
     function routeChange () {


### PR DESCRIPTION
This endpoint allowed the user to send an arbitrary notification. It is unknown *when*, but this has now been restricted to require Admin Credentials.