### PR TITLE
Remove currentAvatarAssetUrl from streaming docs

### DIFF
--- a/content/tutorials/websocket.markdown
+++ b/content/tutorials/websocket.markdown
@@ -324,7 +324,7 @@ A "`friend-location`" event is sent when one of the user's friends has changed i
 User events are relating to the current user logged in.
 
 #### user-update
-A "`user-update`" event is sent when something regarding the user has been updated. Note that the "`user`" object is **not** a LimitedUser object, even though it has similarities. It's missing `developerType`, `friendKey`, `isFriend`, `last_platform` and `location`. It also has extra `currentAvatar` and `currentAvatarAssetUrl` fields.
+A "`user-update`" event is sent when something regarding the user has been updated. Note that the "`user`" object is **not** a LimitedUser object, even though it has similarities. It's missing `developerType`, `friendKey`, `isFriend`, `last_platform` and `location`. It also has an extra `currentAvatar` field.
 
 ```json
 {
@@ -334,7 +334,6 @@ A "`user-update`" event is sent when something regarding the user has been updat
         "user": {
             "bio": ":bioString",
             "currentAvatar": ":avatarId",
-            "currentAvatarAssetUrl": ":assetUrl",
             "currentAvatarImageUrl": ":assetUrl",
             "currentAvatarThumbnailImageUrl": ":assetUrl",
             "displayName": ":displayName",


### PR DESCRIPTION
This field no longer exists. See also: https://github.com/vrchatapi/vrchatapi-dart/pull/33